### PR TITLE
add support for git options in podfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ or
 react-native addpod [pod] --podversion [version]
 ```
 
-or
+or (you can use only one branch/commit/tag option)
 
 ```
-react-native addpod [pod] --podgit[giturl]
+react-native addpod [pod] --podgit[giturl] [--podgitoption "branch=branch_name" "commit=sha" "tag=tag_name"]
 ```
 
 Note that adding a pod puts the reference in your package.json. This gives the hint to react-native link to add it to your Podfile.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -7,6 +7,8 @@ commander
   .description("Add the named pod to the current package.json file")
   .option("--podversion [version]", "version directive")
   .option("--podgit [giturl]", "Git (usually github) source URL")
+  .option("--podgitoption [gitoption]", "Specify the branch, commit or tag like 'branch=branch_name'")
+  .option("--podspec [specurl]", "Podspec for full path/url pointer")
   .action((a, b, c) => {
     return addPod(a, c, b);
   });

--- a/lib/addPod.js
+++ b/lib/addPod.js
@@ -5,7 +5,19 @@ module.exports = (podname, obj, args) => {
   if (typeof podname !== "string") podname = podname[0];
   podinfo = { pod: podname };
   if (args) {
-    const { podversion: version, podgit: git, podspec: spec } = args;
+    const {
+      podversion: version,
+      podgit: git,
+      podgitoption: options,
+      podspec: spec
+    } = args;
+
+    if (git && options) {
+      const [key, value] = options.split('=');
+      if (['branch', 'commit', 'tag'].includes(key)) {
+        podinfo[key] = value;
+      }
+    }
     podinfo = { ...podinfo, version, git, spec };
   }
   if (podinfo) {

--- a/lib/addPodEntry.js
+++ b/lib/addPodEntry.js
@@ -12,7 +12,12 @@ module.exports = function addPodEntry(podLines, linesToAddEntry, podInfo) {
     entryParts.push("'" + podInfo.version + "'");
   }
   if (podInfo.git) {
-    entryParts.push(":git => " + "'" + podInfo.git + "'");
+    entryParts.push("git: " + "'" + podInfo.git + "'");
+    Object.keys(podInfo).forEach((option) => {
+      if (['branch', 'commit', 'tag'].includes(option)) {
+        entryParts.push(option + ": '" + podInfo[option] + "'");
+      }
+    });
   }
   if (podInfo.spec) {
     entryParts.push("podspec: '" + podInfo.spec + "'");

--- a/rnplugin/index.js
+++ b/rnplugin/index.js
@@ -12,7 +12,11 @@ module.exports = [
         description: "Git (usually github) source URL"
       },
       {
-        command: "--podspec <specurl>",
+        command: "--podgitoption [gitption]",
+        description: "Specify the branch, commit or tag like 'branch=branch_name'"
+      },
+      {
+        command: "--podspec [specurl]",
         description: "Podspec for full path/url pointer"
       }
     ],


### PR DESCRIPTION
Cocoapods allows a developer to provide a git branch, commit, or tag along with the git URL, this PR adds that support to react-native-pod